### PR TITLE
mTicksPerRotationInterface->SetMax out of range

### DIFF
--- a/QuadratureAnalyserAnalyzerSettings.cpp
+++ b/QuadratureAnalyserAnalyzerSettings.cpp
@@ -16,6 +16,8 @@
  * $Id: QuadratureAnalyserAnalyzerSettings.cpp 1037 2011-09-12 09:49:58Z dirkx $
  */
 
+#include <climits>
+
 #include "QuadratureAnalyserAnalyzerSettings.h"
 #include <AnalyzerHelpers.h>
 
@@ -36,7 +38,7 @@ QuadratureAnalyserAnalyzerSettings::QuadratureAnalyserAnalyzerSettings()
 	mTicksPerRotationInterface.reset( new AnalyzerSettingInterfaceInteger() );
 	mTicksPerRotationInterface->SetTitleAndTooltip( "Impules/rotation",  
 		"Specify the number of changes per full revolution (or some other measure). Set to '0' to ignore - and not do speed/change calculations.");
-	mTicksPerRotationInterface->SetMax( 1e12 );
+	mTicksPerRotationInterface->SetMax( INT_MAX );
 	mTicksPerRotationInterface->SetMin( 0 );
 	mTicksPerRotationInterface->SetInteger( ticksPerRotation);
 

--- a/QuadratureAnalyserSimulationDataGenerator.cpp
+++ b/QuadratureAnalyserSimulationDataGenerator.cpp
@@ -22,6 +22,7 @@
 
 #include <AnalyzerHelpers.h>
 #include <assert.h>
+#include <random>
 
 QuadratureAnalyserSimulationDataGenerator::QuadratureAnalyserSimulationDataGenerator()
 {
@@ -62,7 +63,6 @@ void QuadratureAnalyserSimulationDataGenerator::Initialize( U32 simulation_sampl
 	}
 
 	mClockGenerator.Init(SCANRATE /* 10 to 5k */, simulation_sample_rate );
-	srand(0);
 }
 
 U32 QuadratureAnalyserSimulationDataGenerator::GenerateSimulationData( U64 largest_sample_requested, U32 sample_rate, SimulationChannelDescriptor** simulation_channel )
@@ -84,14 +84,21 @@ U32 QuadratureAnalyserSimulationDataGenerator::GenerateSimulationData( U64 large
 	fprintf(stderr,"Starting at %lld, run till %lld  - %ld ticks from previous run %s left over\n", 
 		at, adjusted_largest_sample_requested, ticks, DIRSTR(dir));
 #endif
-        while( at < adjusted_largest_sample_requested )
-        {
-		if (ticks <= 0) {
-			speed = 5+(rand() % 11);		// 5 .. 15 tocks/second
-			runtime  = 500 + (rand() %  4500); 	// 0.5 to 5 seconds.
-			dir = rand() % 3;			// in random (or non moving) direction.
-			ticks = 2 * speed * runtime  / 1000;
-	// fprintf(stderr,"speed %d, length %d, ticks %d, %s\n", speed, runtime , ticks, DIRSTR(dir));
+	std::random_device random_device;
+	std::mt19937 random_generator(random_device());
+	std::uniform_int_distribution<int> speed_distribution(5,15);
+	std::uniform_int_distribution<int> runtime_distribution(500,5000);
+	std::uniform_int_distribution<int> dir_distribution(0,2);
+
+	while( at < adjusted_largest_sample_requested )
+	{
+		if( ticks <= 0 )
+		{
+			speed = speed_distribution(random_generator);		// 5 .. 15 tocks/second
+			runtime = runtime_distribution(random_generator); 	// 0.5 to 5 seconds.
+			dir = dir_distribution(random_generator);			// in random (or non moving) direction.
+			ticks = 2 * speed * runtime / 1000;
+			// fprintf(stderr,"speed %d, length %d, ticks %d, %s\n", speed, runtime , ticks, DIRSTR(dir));
 		};
 
 		switch(dir) {


### PR DESCRIPTION
Looks like I accidentally reverted this change before committing last time.

mTicksPerRotationInterface max was set to 1e12, which exceeds a 32 bit signed integer size. On Windows, it gets interpreted as a negative number, and prevents the user from entering any valid number in the Impulse/rotation setting.

This sets the max to INT_MAX which seems to work fine on Windows.